### PR TITLE
feat: implement Age and Gender demographics platform toggles and API integration

### DIFF
--- a/frontend/dashboard/src/components/monthly/AgeDemographicsChart.tsx
+++ b/frontend/dashboard/src/components/monthly/AgeDemographicsChart.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -9,8 +10,50 @@ import {
 } from 'recharts';
 import { AGE_DEMOGRAPHICS } from '../../data/mockData';
 
-const AgeDemographicsChart = () => (
-  <div className="lg:col-span-2 bg-white p-6 rounded-2xl border border-slate-100 shadow-sm">
+const AgeDemographicsChart = () => {
+  const [data, setData] = useState(AGE_DEMOGRAPHICS);
+    useEffect(() => {
+    fetch('http://localhost:3001/fb_page/demographics?dimension=age&access_token=fake_token')
+      .then((res) => res.json())
+      .then((res) => {
+        const values = res.data[0].values[0].value;
+
+        const total =
+          values['13-17'] +
+          values['18-24'] +
+          values['25-34'] +
+          values['35-44'] +
+          values['45-54'] +
+          values['55+'] ||
+          1;
+
+        const metaPercentages = [
+          { age: '13-17', meta: (values['13-17'] / total) * 100 },
+          { age: '18-24', meta: (values['18-24'] / total) * 100 },
+          { age: '25-34', meta: (values['25-34'] / total) * 100 },
+          { age: '35-44', meta: (values['35-44'] / total) * 100 },
+          { age: '45-54', meta: (values['45-54'] / total) * 100 },
+          { age: '55+', meta: (values['55+'] / total) * 100 },
+        ];
+
+        const merged = metaPercentages.map((item) => {
+          const existing = AGE_DEMOGRAPHICS.find((row) => row.age === item.age);
+          return {
+            age: item.age,
+            meta: item.meta,
+            google: existing ? existing.google : 0,
+          };
+        });
+
+        setData(merged);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch age demographics:', err);
+      });
+  }, []);
+
+  return (
+    <div className="lg:col-span-2 bg-white p-6 rounded-2xl border border-slate-100 shadow-sm">
     <div className="flex justify-between items-center mb-5">
       <h3 className="text-base font-black text-slate-900">Age Demographics</h3>
       <div className="flex gap-4">
@@ -26,7 +69,7 @@ const AgeDemographicsChart = () => (
     </div>
     <div className="h-[260px] w-full">
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={AGE_DEMOGRAPHICS} barGap={8} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+        <BarChart data={data} barGap={8} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
           <XAxis
             dataKey="age"
@@ -46,6 +89,7 @@ const AgeDemographicsChart = () => (
       </ResponsiveContainer>
     </div>
   </div>
-);
+  );
+};
 
 export default AgeDemographicsChart;

--- a/frontend/dashboard/src/components/monthly/AgeDemographicsChart.tsx
+++ b/frontend/dashboard/src/components/monthly/AgeDemographicsChart.tsx
@@ -10,85 +10,155 @@ import {
 } from 'recharts';
 import { AGE_DEMOGRAPHICS } from '../../data/mockData';
 
+type PlatformMode = 'meta' | 'facebook' | 'instagram';
+
+type AgeValues = {
+  '13-17': number;
+  '18-24': number;
+  '25-34': number;
+  '35-44': number;
+  '45-54': number;
+  '55+': number;
+};
+
+const AGE_GROUPS: (keyof AgeValues)[] = ['13-17', '18-24', '25-34', '35-44', '45-54', '55+'];
+
 const AgeDemographicsChart = () => {
+  const [mode, setMode] = useState<PlatformMode>('meta');
   const [data, setData] = useState(AGE_DEMOGRAPHICS);
-    useEffect(() => {
-    fetch('http://localhost:3001/fb_page/demographics?dimension=age&access_token=fake_token')
-      .then((res) => res.json())
-      .then((res) => {
-        const values = res.data[0].values[0].value;
 
-        const total =
-          values['13-17'] +
-          values['18-24'] +
-          values['25-34'] +
-          values['35-44'] +
-          values['45-54'] +
-          values['55+'] ||
-          1;
+  useEffect(() => {
+    const fbUrl =
+      'http://localhost:3001/fb_page/demographics?dimension=age&access_token=fake_token';
+    const igUrl =
+      'http://localhost:3001/ig_account/demographics?dimension=age&access_token=fake_token';
 
-        const metaPercentages = [
-          { age: '13-17', meta: (values['13-17'] / total) * 100 },
-          { age: '18-24', meta: (values['18-24'] / total) * 100 },
-          { age: '25-34', meta: (values['25-34'] / total) * 100 },
-          { age: '35-44', meta: (values['35-44'] / total) * 100 },
-          { age: '45-54', meta: (values['45-54'] / total) * 100 },
-          { age: '55+', meta: (values['55+'] / total) * 100 },
-        ];
+    const formatAgeData = (values: AgeValues) => {
+      const total =
+        AGE_GROUPS.reduce((sum, group) => sum + values[group], 0) || 1;
 
-        const merged = metaPercentages.map((item) => {
-          const existing = AGE_DEMOGRAPHICS.find((row) => row.age === item.age);
-          return {
-            age: item.age,
-            meta: item.meta,
-            google: existing ? existing.google : 0,
-          };
-        });
+      return AGE_GROUPS.map((age) => {
+        const existing = AGE_DEMOGRAPHICS.find((row) => row.age === age);
 
-        setData(merged);
-      })
-      .catch((err) => {
-        console.error('Failed to fetch age demographics:', err);
+        return {
+          age,
+          meta: (values[age] / total) * 100,
+          google: existing ? existing.google : 0,
+        };
       });
-  }, []);
+    };
+
+    const getLatestValues = (res: { data: { values: { value: AgeValues }[] }[] }) => {
+      const valuesList = res.data[0].values;
+      return valuesList[valuesList.length - 1].value;
+    };
+
+    if (mode === 'facebook') {
+      fetch(fbUrl)
+        .then((res) => res.json())
+        .then((res) => {
+          const values = getLatestValues(res);
+          setData(formatAgeData(values));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Facebook age demographics:', err);
+        });
+    }
+
+    if (mode === 'instagram') {
+      fetch(igUrl)
+        .then((res) => res.json())
+        .then((res) => {
+          const values = getLatestValues(res);
+          setData(formatAgeData(values));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Instagram age demographics:', err);
+        });
+    }
+
+    if (mode === 'meta') {
+      Promise.all([
+        fetch(fbUrl).then((res) => res.json()),
+        fetch(igUrl).then((res) => res.json()),
+      ])
+        .then(([fbRes, igRes]) => {
+          const fbValues = getLatestValues(fbRes);
+          const igValues = getLatestValues(igRes);
+
+          const combined = AGE_GROUPS.reduce((result, age) => {
+            result[age] = fbValues[age] + igValues[age];
+            return result;
+          }, {} as AgeValues);
+
+          setData(formatAgeData(combined));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Meta age demographics:', err);
+        });
+    }
+  }, [mode]);
 
   return (
     <div className="lg:col-span-2 bg-white p-6 rounded-2xl border border-slate-100 shadow-sm">
-    <div className="flex justify-between items-center mb-5">
-      <h3 className="text-base font-black text-slate-900">Age Demographics</h3>
-      <div className="flex gap-4">
-        <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-slate-900" />
-          <span className="text-xs font-bold text-slate-500">Meta</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-brand-yellow" />
-          <span className="text-xs font-bold text-slate-500">Google</span>
+      <div className="flex justify-between items-center mb-5">
+        <h3 className="text-base font-black text-slate-900">Age Demographics</h3>
+
+        <div className="flex items-center gap-4">
+          <div className="flex bg-slate-100 p-1 rounded-xl">
+            {(['meta', 'facebook', 'instagram'] as PlatformMode[]).map((option) => (
+              <button
+                key={option}
+                onClick={() => setMode(option)}
+                className={`px-3 py-1 rounded-lg text-xs font-bold capitalize transition ${
+                  mode === option
+                    ? 'bg-white text-slate-900 shadow-sm'
+                    : 'text-slate-500 hover:text-slate-900'
+                }`}
+              >
+                {option === 'meta' ? 'Meta' : option === 'facebook' ? 'Facebook' : 'Instagram'}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-4">
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-slate-900" />
+              <span className="text-xs font-bold text-slate-500">
+                {mode === 'meta' ? 'Meta' : mode === 'facebook' ? 'Facebook' : 'Instagram'}
+              </span>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-brand-yellow" />
+              <span className="text-xs font-bold text-slate-500">Google</span>
+            </div>
+          </div>
         </div>
       </div>
+
+      <div className="h-[260px] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} barGap={8} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
+            <XAxis
+              dataKey="age"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: '#94a3b8', fontSize: 12, fontWeight: 600 }}
+              dy={10}
+            />
+            <YAxis hide />
+            <Tooltip
+              cursor={{ fill: '#f8fafc' }}
+              contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1)' }}
+            />
+            <Bar dataKey="meta" fill="#0f172a" radius={[4, 4, 0, 0]} barSize={32} />
+            <Bar dataKey="google" fill="#FFB800" radius={[4, 4, 0, 0]} barSize={32} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
     </div>
-    <div className="h-[260px] w-full">
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} barGap={8} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
-          <XAxis
-            dataKey="age"
-            axisLine={false}
-            tickLine={false}
-            tick={{ fill: '#94a3b8', fontSize: 12, fontWeight: 600 }}
-            dy={10}
-          />
-          <YAxis hide />
-          <Tooltip
-            cursor={{ fill: '#f8fafc' }}
-            contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1)' }}
-          />
-          <Bar dataKey="meta" fill="#0f172a" radius={[4, 4, 0, 0]} barSize={32} />
-          <Bar dataKey="google" fill="#FFB800" radius={[4, 4, 0, 0]} barSize={32} />
-        </BarChart>
-      </ResponsiveContainer>
-    </div>
-  </div>
   );
 };
 

--- a/frontend/dashboard/src/components/monthly/GenderDistributionChart.tsx
+++ b/frontend/dashboard/src/components/monthly/GenderDistributionChart.tsx
@@ -1,21 +1,59 @@
+import { useEffect, useState } from 'react';
 import { ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
-import { GENDER_DISTRIBUTION } from '../../data/mockData';
 
 const GenderDistributionChart = () => {
-  const dominant = [...GENDER_DISTRIBUTION].sort((a, b) => b.value - a.value)[0];
+  const [data, setData] = useState([
+    { name: 'Female', value: 0, color: '#8884d8' },
+    { name: 'Male', value: 0, color: '#82ca9d' },
+    { name: 'Unknown', value: 0, color: '#ffc658' },
+  ]);
+
+  const dominant = [...data].sort((a, b) => b.value - a.value)[0];
+
+    useEffect(() => {
+    fetch('http://localhost:3001/fb_page/demographics?dimension=gender&access_token=fake_token')
+      .then((res) => res.json())
+      .then((res) => {
+        const values = res.data[0].values[0].value;
+        const total = values.female + values.male + values.unknown || 1;
+
+        const formatted = [
+  { 
+    name: 'Female', 
+    value: (values.female / total) * 100, 
+    color: '#8884d8' 
+  },
+  { 
+    name: 'Male', 
+    value: (values.male / total) * 100, 
+    color: '#82ca9d' 
+  },
+  { 
+    name: 'Unknown', 
+    value: (values.unknown / total) * 100, 
+    color: '#ffc658' 
+  },
+];
+
+        setData(formatted);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch gender demographics:', err);
+      });
+  }, []);
 
   return (
     <div className="bg-white p-6 rounded-2xl border border-slate-100 shadow-sm flex flex-col">
       <h3 className="text-base font-black text-slate-900 mb-4">Gender Distribution</h3>
       <div className="flex-1 relative flex items-center justify-center">
         <div className="absolute text-center">
-          <p className="text-3xl font-black text-slate-900">{Math.round(dominant.value)}%</p>
+          <p className="text-3xl font-black text-slate-900">{dominant.value.toFixed(1)}%</p>
           <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">{dominant.name} Majority</p>
         </div>
         <ResponsiveContainer width="100%" height={210}>
           <PieChart>
-            <Pie data={GENDER_DISTRIBUTION} innerRadius={65} outerRadius={82} paddingAngle={5} dataKey="value">
-              {GENDER_DISTRIBUTION.map((entry, index) => (
+            <Pie data={data} innerRadius={65} outerRadius={82} paddingAngle={5} dataKey="value">
+              {data.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.color} />
               ))}
             </Pie>
@@ -23,13 +61,13 @@ const GenderDistributionChart = () => {
         </ResponsiveContainer>
       </div>
       <div className="space-y-3 mt-4">
-        {GENDER_DISTRIBUTION.map((item, i) => (
+        {data.map((item, i) => (
           <div key={i} className="flex justify-between items-center">
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
               <span className="text-sm font-bold text-slate-600">{item.name}</span>
             </div>
-            <span className="text-sm font-black text-slate-900">{item.value}%</span>
+            <span className="text-sm font-black text-slate-900">{{item.value.toFixed(1)}%</span>
           </div>
         ))}
       </div>

--- a/frontend/dashboard/src/components/monthly/GenderDistributionChart.tsx
+++ b/frontend/dashboard/src/components/monthly/GenderDistributionChart.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 import { ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 
+type PlatformMode = 'meta' | 'facebook' | 'instagram';
+
 const GenderDistributionChart = () => {
+  const [mode, setMode] = useState<PlatformMode>('meta');
   const [data, setData] = useState([
     { name: 'Female', value: 0, color: '#8884d8' },
     { name: 'Male', value: 0, color: '#82ca9d' },
@@ -10,46 +13,108 @@ const GenderDistributionChart = () => {
 
   const dominant = [...data].sort((a, b) => b.value - a.value)[0];
 
-    useEffect(() => {
-    fetch('http://localhost:3001/fb_page/demographics?dimension=gender&access_token=fake_token')
-      .then((res) => res.json())
-      .then((res) => {
-        const values = res.data[0].values[0].value;
-        const total = values.female + values.male + values.unknown || 1;
+  useEffect(() => {
+    const fbUrl =
+      'http://localhost:3001/fb_page/demographics?dimension=gender&access_token=fake_token';
+    const igUrl =
+      'http://localhost:3001/ig_account/demographics?dimension=gender&access_token=fake_token';
 
-        const formatted = [
-  { 
-    name: 'Female', 
-    value: (values.female / total) * 100, 
-    color: '#8884d8' 
-  },
-  { 
-    name: 'Male', 
-    value: (values.male / total) * 100, 
-    color: '#82ca9d' 
-  },
-  { 
-    name: 'Unknown', 
-    value: (values.unknown / total) * 100, 
-    color: '#ffc658' 
-  },
-];
+    const formatGenderData = (values: { female: number; male: number; unknown: number }) => {
+      const total = values.female + values.male + values.unknown || 1;
 
-        setData(formatted);
-      })
-      .catch((err) => {
-        console.error('Failed to fetch gender demographics:', err);
-      });
-  }, []);
+      return [
+        {
+          name: 'Female',
+          value: (values.female / total) * 100,
+          color: '#8884d8',
+        },
+        {
+          name: 'Male',
+          value: (values.male / total) * 100,
+          color: '#82ca9d',
+        },
+        {
+          name: 'Unknown',
+          value: (values.unknown / total) * 100,
+          color: '#ffc658',
+        },
+      ];
+    };
+
+    if (mode === 'facebook') {
+      fetch(fbUrl)
+        .then((res) => res.json())
+        .then((res) => {
+          const values = res.data[0].values[0].value;
+          setData(formatGenderData(values));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Facebook gender demographics:', err);
+        });
+    }
+
+    if (mode === 'instagram') {
+      fetch(igUrl)
+        .then((res) => res.json())
+        .then((res) => {
+          const values = res.data[0].values[0].value;
+          setData(formatGenderData(values));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Instagram gender demographics:', err);
+        });
+    }
+
+    if (mode === 'meta') {
+      Promise.all([fetch(fbUrl).then((res) => res.json()), fetch(igUrl).then((res) => res.json())])
+        .then(([fbRes, igRes]) => {
+          const fbValues = fbRes.data[0].values[0].value;
+          const igValues = igRes.data[0].values[0].value;
+
+          const combined = {
+            female: fbValues.female + igValues.female,
+            male: fbValues.male + igValues.male,
+            unknown: fbValues.unknown + igValues.unknown,
+          };
+
+          setData(formatGenderData(combined));
+        })
+        .catch((err) => {
+          console.error('Failed to fetch Meta gender demographics:', err);
+        });
+    }
+  }, [mode]);
 
   return (
     <div className="bg-white p-6 rounded-2xl border border-slate-100 shadow-sm flex flex-col">
-      <h3 className="text-base font-black text-slate-900 mb-4">Gender Distribution</h3>
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-base font-black text-slate-900">Gender Distribution</h3>
+
+        <div className="flex bg-slate-100 p-1 rounded-xl">
+          {(['meta', 'facebook', 'instagram'] as PlatformMode[]).map((option) => (
+            <button
+              key={option}
+              onClick={() => setMode(option)}
+              className={`px-3 py-1 rounded-lg text-xs font-bold capitalize transition ${
+                mode === option
+                  ? 'bg-white text-slate-900 shadow-sm'
+                  : 'text-slate-500 hover:text-slate-900'
+              }`}
+            >
+              {option === 'meta' ? 'Meta' : option === 'facebook' ? 'Facebook' : 'Instagram'}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div className="flex-1 relative flex items-center justify-center">
         <div className="absolute text-center">
           <p className="text-3xl font-black text-slate-900">{dominant.value.toFixed(1)}%</p>
-          <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">{dominant.name} Majority</p>
+          <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">
+            {dominant.name} Majority
+          </p>
         </div>
+
         <ResponsiveContainer width="100%" height={210}>
           <PieChart>
             <Pie data={data} innerRadius={65} outerRadius={82} paddingAngle={5} dataKey="value">
@@ -60,6 +125,7 @@ const GenderDistributionChart = () => {
           </PieChart>
         </ResponsiveContainer>
       </div>
+
       <div className="space-y-3 mt-4">
         {data.map((item, i) => (
           <div key={i} className="flex justify-between items-center">
@@ -67,7 +133,7 @@ const GenderDistributionChart = () => {
               <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
               <span className="text-sm font-bold text-slate-600">{item.name}</span>
             </div>
-            <span className="text-sm font-black text-slate-900">{{item.value.toFixed(1)}%</span>
+            <span className="text-sm font-black text-slate-900">{item.value.toFixed(1)}%</span>
           </div>
         ))}
       </div>


### PR DESCRIPTION
This PR implements platform toggle support for both Age Demographics and Gender Distribution charts.

Main changes:
- Added Meta / Facebook / Instagram toggle for Age Demographics
- Added Meta / Facebook / Instagram toggle for Gender Distribution
- Integrated fake Meta API for age and gender demographics data
- Converted raw API values into percentage format for visualization
- Aggregated Facebook and Instagram data for Meta mode
- Updated charts dynamically based on selected platform

Testing:
- Backend fake API running on localhost:3001
- Verified correct endpoints are triggered:
  - /fb_page/demographics?dimension=age
  - /ig_account/demographics?dimension=age
  - /fb_page/demographics?dimension=gender
  - /ig_account/demographics?dimension=gender
- Both charts update correctly when switching between Meta, Facebook, and Instagram

Main changed files:
- frontend/dashboard/src/components/monthly/AgeDemographicsChart.tsx
- frontend/dashboard/src/components/monthly/GenderDistributionChart.tsx