### PR TITLE
feat: edit and delete for custom metrics + confirmation dialog

### DIFF
--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -11,10 +11,10 @@ router = APIRouter(tags=["Metrics"])
 
 
 class MetricEntry(BaseModel):
-    metric_name: str
-    date: str
-    value: str
-    platform: str 
+    metric_name: str | None = None
+    date: str | None = None
+    value: str | None = None
+    platform: str | None = None
 
 
 @router.get("/metrics")
@@ -42,11 +42,10 @@ def add_metric(entry: MetricEntry):
 @router.put("/metrics/{id}")
 def update_metric(id: int, entry: MetricEntry):
     try:
-        response = supabase.table("metrics_entries").update({
-            "metric_name": entry.metric_name,
-            "date": entry.date,
-            "value": entry.value,
-        }).eq("id", id).execute()
+        updates = {k: v for k, v in entry.model_dump().items() if v is not None}
+        if not updates:
+            raise HTTPException(status_code=400, detail="No fields to update")
+        response = supabase.table("metrics_entries").update(updates).eq("id", id).execute()
         if not response.data:
             raise HTTPException(status_code=404, detail="Metric not found")
         return {"success": True, "item": response.data[0]}

--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -36,3 +36,32 @@ def add_metric(entry: MetricEntry):
         return {"success": True, "item": response.data[0]}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+    
+@router.put("/metrics/{id}")
+def update_metric(id: int, entry: MetricEntry):
+    try:
+        response = supabase.table("metrics_entries").update({
+            "metric_name": entry.metric_name,
+            "date": entry.date,
+            "value": entry.value,
+        }).eq("id", id).execute()
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Metric not found")
+        return {"success": True, "item": response.data[0]}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/metrics/{id}")
+def delete_metric(id: int):
+    try:
+        response = supabase.table("metrics_entries").delete().eq("id", id).execute()
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Metric not found")
+        return {"success": True, "deleted_id": id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/dashboard/src/components/custom/CustomMetric.tsx
+++ b/frontend/dashboard/src/components/custom/CustomMetric.tsx
@@ -1,4 +1,5 @@
-import { BarChart2 } from "lucide-react";
+import { BarChart2, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
 
 type CustomMetric = {
   id: string;
@@ -6,9 +7,51 @@ type CustomMetric = {
   platform: string;
   value: string;
   date: string;
+  onDelete: (id: string) => void;
+  onEdit: (id: string, updated: { metric_name: string; date: string; value: string }) => void;
 };
 
-const Record = ({ metric_name, platform, value, date }: CustomMetric) => {
+const Record = ({ id, metric_name, platform, value, date, onDelete, onEdit }: CustomMetric) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(metric_name);
+  const [editValue, setEditValue] = useState(value);
+  const [editDate, setEditDate] = useState(date);
+
+  const handleSave = async () => {
+    const res = await fetch(`http://localhost:8000/api/v1/metrics/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ metric_name: editName, date: editDate, value: editValue }),
+    });
+    if (res.ok) {
+      onEdit(id, { metric_name: editName, date: editDate, value: editValue });
+      setIsEditing(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const res = await fetch(`http://localhost:8000/api/v1/metrics/${id}`, { method: "DELETE" });
+    if (res.ok) onDelete(id);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="grid grid-cols-[2fr_1fr_1fr_1fr_0.5fr] items-center px-4 py-3 border-b border-slate-100 gap-2">
+        <input value={editName} onChange={(e) => setEditName(e.target.value)}
+          className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm font-semibold text-slate-900 outline-none focus:ring-2 focus:ring-brand-yellow" />
+        <span className="bg-brand-cream text-brand-brown text-[10px] font-bold px-3 py-1 rounded-full uppercase w-fit">{platform || "—"}</span>
+        <input value={editValue} onChange={(e) => setEditValue(e.target.value)}
+          className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm font-bold text-slate-900 outline-none focus:ring-2 focus:ring-brand-yellow" />
+        <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)}
+          className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm text-slate-500 outline-none focus:ring-2 focus:ring-brand-yellow" />
+        <div className="flex gap-1">
+          <button onClick={handleSave} className="text-xs bg-brand-brown text-white px-2 py-1 rounded-lg font-semibold">Save</button>
+          <button onClick={() => setIsEditing(false)} className="text-xs border border-slate-200 px-2 py-1 rounded-lg text-slate-500">Cancel</button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-[2fr_1fr_1fr_1fr_0.5fr] items-center px-4 py-5 border-b border-slate-100">
       <div className="flex items-center gap-3">
@@ -17,10 +60,19 @@ const Record = ({ metric_name, platform, value, date }: CustomMetric) => {
         </div>
         <p className="font-semibold text-slate-900">{metric_name || "Unknown"}</p>
       </div>
-      <span className="bg-brand-cream text-brand-brown text-[10px] font-bold px-3 py-1 rounded-full uppercase w-fit">{platform || "Unknown"}</span>
+      <span className="bg-brand-cream text-brand-brown text-[10px] font-bold px-3 py-1 rounded-full uppercase w-fit">{platform || "—"}</span>
       <p className="font-bold text-slate-900">{value || "Unknown"}</p>
       <p className="text-slate-500">{date || "Unknown"}</p>
+      <div className="flex gap-2">
+        <button onClick={() => setIsEditing(true)} className="text-slate-400 hover:text-brand-brown transition">
+          <Pencil size={15} />
+        </button>
+        <button onClick={handleDelete} className="text-slate-400 hover:text-red-500 transition">
+          <Trash2 size={15} />
+        </button>
+      </div>
     </div>
   );
 };
+
 export default Record;

--- a/frontend/dashboard/src/components/custom/CustomMetric.tsx
+++ b/frontend/dashboard/src/components/custom/CustomMetric.tsx
@@ -16,12 +16,13 @@ const Record = ({ id, metric_name, platform, value, date, onDelete, onEdit }: Cu
   const [editName, setEditName] = useState(metric_name);
   const [editValue, setEditValue] = useState(value);
   const [editDate, setEditDate] = useState(date);
+  const [editPlatform, setEditPlatform] = useState(platform);
 
   const handleSave = async () => {
     const res = await fetch(`http://localhost:8000/api/v1/metrics/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ metric_name: editName, date: editDate, value: editValue }),
+      body: JSON.stringify({ metric_name: editName, date: editDate, value: editValue, platform: editPlatform }),
     });
     if (res.ok) {
       onEdit(id, { metric_name: editName, date: editDate, value: editValue });
@@ -39,7 +40,9 @@ const Record = ({ id, metric_name, platform, value, date, onDelete, onEdit }: Cu
       <div className="grid grid-cols-[2fr_1fr_1fr_1fr_0.5fr] items-center px-4 py-3 border-b border-slate-100 gap-2">
         <input value={editName} onChange={(e) => setEditName(e.target.value)}
           className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm font-semibold text-slate-900 outline-none focus:ring-2 focus:ring-brand-yellow" />
-        <span className="bg-brand-cream text-brand-brown text-[10px] font-bold px-3 py-1 rounded-full uppercase w-fit">{platform || "—"}</span>
+        <input value={editPlatform} onChange={(e) => setEditPlatform(e.target.value)}
+  placeholder="Platform"
+  className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm text-brand-brown outline-none focus:ring-2 focus:ring-brand-yellow" />
         <input value={editValue} onChange={(e) => setEditValue(e.target.value)}
           className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm font-bold text-slate-900 outline-none focus:ring-2 focus:ring-brand-yellow" />
         <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)}

--- a/frontend/dashboard/src/components/custom/CustomMetric.tsx
+++ b/frontend/dashboard/src/components/custom/CustomMetric.tsx
@@ -17,6 +17,7 @@ const Record = ({ id, metric_name, platform, value, date, onDelete, onEdit }: Cu
   const [editValue, setEditValue] = useState(value);
   const [editDate, setEditDate] = useState(date);
   const [editPlatform, setEditPlatform] = useState(platform);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const handleSave = async () => {
     const res = await fetch(`http://localhost:8000/api/v1/metrics/${id}`, {
@@ -70,9 +71,16 @@ const Record = ({ id, metric_name, platform, value, date, onDelete, onEdit }: Cu
         <button onClick={() => setIsEditing(true)} className="text-slate-400 hover:text-brand-brown transition">
           <Pencil size={15} />
         </button>
-        <button onClick={handleDelete} className="text-slate-400 hover:text-red-500 transition">
-          <Trash2 size={15} />
-        </button>
+        {confirmDelete ? (
+  <div className="flex gap-1">
+    <button onClick={handleDelete} className="text-xs bg-red-500 text-white px-2 py-1 rounded-lg font-semibold">Yes</button>
+    <button onClick={() => setConfirmDelete(false)} className="text-xs border border-slate-200 px-2 py-1 rounded-lg text-slate-500">No</button>
+  </div>
+) : (
+  <button onClick={() => setConfirmDelete(true)} className="text-slate-400 hover:text-red-500 transition">
+    <Trash2 size={15} />
+  </button>
+)}
       </div>
     </div>
   );

--- a/frontend/dashboard/src/components/custom/CustomMetricsTable.tsx
+++ b/frontend/dashboard/src/components/custom/CustomMetricsTable.tsx
@@ -81,6 +81,8 @@ export default function CustomMetricsTable() {
               platform={record.platform}
               value={record.value}
               date={record.date}
+              onDelete={(id) => setRecords(records.filter((r) => r.id !== id))}
+              onEdit={(id, updated) => setRecords(records.map((r) => r.id === id ? { ...r, ...updated } : r))}
             />
           ))
         )}


### PR DESCRIPTION
Adds edit and delete functionality to each row in the 
custom metrics table, with a confirmation step before deleting.

## Changes
- CustomMetric.tsx: added inline edit mode and delete confirmation
- CustomMetricsTable.tsx: passes onEdit and onDelete handlers to each row
- api/routes/metrics.py: added PUT and DELETE endpoints, made all 
  MetricEntry fields optional

## How to test
1. Make sure you're on this branch and in the root folder
2. Run the backend:
   uv run --with fastapi --with uvicorn --with pandas --with supabase uvicorn api.main:app --reload

3. In a separate terminal, run the frontend:
   cd frontend/dashboard
   npm run dev

4. Open http://localhost:3000 and log in

5. Navigate to the Custom Metrics page

6. Add a new entry using the + New Entry button

7. Test edit:
   - Click the pencil icon on any row
   - Edit any fields and click Save
   - Row should update without page refresh

8. Test delete:
   - Click the trash icon on any row
   - Confirm you see Yes/No buttons appear
   - Click Yes to confirm deletion
   - Row should disappear without page refresh

## Notes
- Backend must be running for the page to load data
- All MetricEntry fields are now optional in the API